### PR TITLE
added support for the base argument from gulp.src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 ./fixture
+.idea
+.project

--- a/index.js
+++ b/index.js
@@ -34,8 +34,13 @@ module.exports = function (options) {
 		// have to create a new connection for each file otherwise they conflict
 		var ftp = new JSFtp(options);
 		var relativePath = file.path.replace(file.cwd + '/', '');
-    var localRelativePath = file.path.replace(path.join(file.cwd, localPath), '');
+		
+		
+		var fileBase = file.base?path.resolve(file.base) : file.cwd;
+		
+		var localRelativePath = file.path.replace(path.join(fileBase, localPath), '');
 		var finalRemotePath = path.join('/', remotePath, localRelativePath);
+		
 
 		ftp.mkdirp(path.dirname(finalRemotePath), function (err) {
 			if (err) {


### PR DESCRIPTION
It felt more natural to use the base argument from the file object to determine the remote path. This is what the option localPath was created for, but it felt more gulp to do it this way. Thoughts?
